### PR TITLE
Update Dockerfile

### DIFF
--- a/Source/Dockerfile
+++ b/Source/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /tmp
 #install the dependencies
 RUN yum -y install gcc-c++ && yum -y install findutils
 
+RUN yum -y install tar gzip
+
 RUN touch ~/.bashrc && chmod +x ~/.bashrc
 
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash


### PR DESCRIPTION
amazonlinux에 tar와 gzip이 포함되어 있지 않아서 build 명령시에 tar: command not found 오류가 납니다. tar, gzip 설치후 해결되었습니다.